### PR TITLE
added TOML file GH-19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.poetry]
+name = "deliverease"
+version = "0.1.0"
+description = ""
+authors = ["Team DeliverEase"]
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = "^3.10"
+Django = "^4.2.4"
+sqlparse = "^0.4.4"
+typing-extensions = "^4.7.1"
+tzdata = "^2023.3"
+asgiref = "^3.7.2"
+
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.pydocstyle]
+match = "(?!_init_|000).*.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.poetry]
-name = "deliverease"
+name = "DeliverEase"
 version = "0.1.0"
 description = ""
-authors = ["Team DeliverEase"]
+authors = ["CodeArena"]
 readme = "README.md"
 
 [tool.poetry.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,5 @@
+
+## run poetry install to install the dependencies listed in the file
 [tool.poetry]
 name = "DeliverEase"
 version = "0.1.0"


### PR DESCRIPTION
Poetry install to install the dependencies listed in the TOML file
Added the pyproj.toml file which is used by the developers using poetry venv to install dependencies . hence fixed #19.
cc: @SID262000 , and also i think we should only keep the toml file instead of the setup.py as both of them has the same role and modern developers and guides are switching from setup.py to toml 
