### PR TITLE
Fixed logging error in pre-commit hook

### DIFF
--- a/_hooks/pre-commit
+++ b/_hooks/pre-commit
@@ -11,11 +11,22 @@ run_python_linters() {
     # Installing linters in case they are not installed
     linters=(pylint flake8 ruff black pycodestyle pydocstyle)
     for linter in ${linters[@]}; do 
-        pip show $linter > /dev/null
-        if [ $? -ne 0 ]; then
-            read -p "Install $linter?[y/n] " answer
+        # Handling black separately because it throws error in git bash on windows.
+        if [[ $linter == "black" ]]; then
+            pip show $linter > /dev/null 2>&1
+            exit_code=$?
+            if [[ $exit_code -ne 0 ]];  then
+                echo "WARNING: package not found: black"
+            fi
+        else
+            pip show $linter > /dev/null
+            exit_code=$?
+        fi
+
+        if [ $exit_code -ne 0 ]; then
+            read -p "Install $linter?[y/n] " answer 
             if [[ $answer =~ ^[Yy] ]]; then
-                pip install $linter || exit 1
+                python3 -m pip install $linter || exit 1
             else
                 echo "Requirements not met, commit aborted."
                 exit 1
@@ -32,23 +43,23 @@ run_python_linters() {
 
     for file in $staged_files; do
         if [[ $file = *.py && $file != */migrations/* && $file != *test* && $file != *settings* && $file != *init* ]]; then
-
+    
             echo -e "File Path: $file\n" >> logs/linter.log
 
             echo -e "FLAKE8:" >> logs/linter.log
-            flake8 $file >> logs/linter.log
+            python3 -m flake8 $file >> logs/linter.log
 
             echo -e "PYCODESTYLE:" >> logs/linter.log
-            pycodestyle $file >> logs/linter.log
+            python3 -m pycodestyle $file >> logs/linter.log
 
             echo -e "PYLINT:" >> logs/linter.log
-            pylint $file >> logs/linter.log
+            python3 -m pylint $file >> logs/linter.log
 
             echo -e "BLACK:" >> logs/linter.log
-            black --diff $file >> logs/linter.log 2>&1
+            python3 -m black --diff $file >> logs/linter.log 2>&1
 
             echo -e "RUFF:" >> logs/linter.log
-            ruff check $file >> logs/linter.log
+            python3 -m ruff check $file >> logs/linter.log
 
             # echo -e "\n PYDOCSTYLE \n" >> logs/linter.log
             # pydocstyle . >> logs/linter.log 
@@ -61,11 +72,7 @@ run_python_linters() {
 
     done
     
-    if [[ $(uname -s) == "Linux" || $(uname -s) == "Darwin" ]]; then # for linux and MacOS
-        cat logs/linter.log
-    elif [[ $(uname -s) == "MINGW"* ]]; then  # Windows
-        type logs/linter.log
-    fi 
+    cat logs/linter.log
 
     if [[ $fail != false ]]; then
         echo "Python linters failed, Commit aborted."
@@ -79,13 +86,12 @@ ins_empty_line(){
     staged_files=$(git diff --cached --name-only --diff-filter=AMR)
 
     for file in $staged_files; do
-        last_line=$(tail -n 1 "$file")
-        if [ -n "$last_line" ]; then
-            echo "" >> "$file"
+        last_char=$(tail -c 1 $file)
+        if [[ "$last_char" != "" ]]; then
+            echo >> "$file"
         fi
     done
 }
 
 ins_empty_line
-run_python_linters      
-
+run_python_linters

--- a/_hooks/pre-commit
+++ b/_hooks/pre-commit
@@ -26,7 +26,7 @@ run_python_linters() {
         if [ $exit_code -ne 0 ]; then
             read -p "Install $linter?[y/n] " answer 
             if [[ $answer =~ ^[Yy] ]]; then
-                python3 -m pip install $linter || exit 1
+                python -m pip install $linter || exit 1
             else
                 echo "Requirements not met, commit aborted."
                 exit 1
@@ -47,19 +47,19 @@ run_python_linters() {
             echo -e "File Path: $file\n" >> logs/linter.log
 
             echo -e "FLAKE8:" >> logs/linter.log
-            python3 -m flake8 $file >> logs/linter.log
+            python -m flake8 $file >> logs/linter.log
 
             echo -e "PYCODESTYLE:" >> logs/linter.log
-            python3 -m pycodestyle $file >> logs/linter.log
+            python -m pycodestyle $file >> logs/linter.log
 
             echo -e "PYLINT:" >> logs/linter.log
-            python3 -m pylint $file >> logs/linter.log
+            python -m pylint $file >> logs/linter.log
 
             echo -e "BLACK:" >> logs/linter.log
-            python3 -m black --diff $file >> logs/linter.log 2>&1
+            python -m black --diff $file >> logs/linter.log 2>&1
 
             echo -e "RUFF:" >> logs/linter.log
-            python3 -m ruff check $file >> logs/linter.log
+            python -m ruff check $file >> logs/linter.log
 
             # echo -e "\n PYDOCSTYLE \n" >> logs/linter.log
             # pydocstyle . >> logs/linter.log 
@@ -72,7 +72,7 @@ run_python_linters() {
 
     done
     
-    cat logs/linter.log
+    cat logs/linter.log 
 
     if [[ $fail != false ]]; then
         echo "Python linters failed, Commit aborted."


### PR DESCRIPTION
The pre-commit hook was throwing error in git bash on Windows.  The error was occurring due to some issue in **black linter** and therefore I've added separate handling for black in the installation script.